### PR TITLE
Build matrix feature doesn't play well with `os:` key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
       env: CC=clang-3.6
     - compiler: clang
       env: CC=clang-3.7
-os:
-    - linux
 
 # install "python3" used in the test script
 before_install:


### PR DESCRIPTION
Can you give this a try?